### PR TITLE
Rework SpinWheel to be mobile-friendly

### DIFF
--- a/src/client/App.vue
+++ b/src/client/App.vue
@@ -14,10 +14,10 @@
 
     <b-container>
       <b-row>
-        <b-col>
+        <b-col sm='12' md='6'>
           <SpinWheel v-if='dayOptions' :segments='dayOptions' class='dayWheel' />
         </b-col>
-        <b-col>
+        <b-col sm='12' md='6'>
           <div v-if='selectedDay'>
             <b-card :title='selectedDay.label' :img-src='selectedDay.img' style='max-width: 30rem; margin: auto;'>
               <b-card-text>{{selectedDay.info}}</b-card-text>
@@ -64,7 +64,6 @@ export default {
 
 <style>
 .dayWheel {
-  width: 30rem;
-  height: 30rem;
+  width: 100%;
 }
 </style>

--- a/src/client/components/SpinWheel.vue
+++ b/src/client/components/SpinWheel.vue
@@ -45,60 +45,51 @@ export default {
   created: function () {
     this.calculatedSegments = calculateSegments(this.segments)
   },
-  updated: function () {
-    this.calculatedSegments = calculateSegments(this.segments)
-    // TODO re-render when props change
-  },
   mounted: function () {
     this.app = new PIXI.Application({
       antialias: true,
-      resizeTo: this.$refs.myCanvas,
       transparent: true
     })
-    this.app.renderer.autoResize = true
 
-    const wheel = new PIXI.Container()
-    wheel.x = this.app.view.width / 2
-    wheel.y = this.app.view.height / 2
+    this.wheel = new PIXI.Container()
+    this.app.stage.addChild(this.wheel)
 
-    const radius = this.app.view.height / 2 - 10
-    let degreesUsed = 0
-    for (const calculatedSegment of this.calculatedSegments) {
-      const segment = new PIXI.Container()
+    // Draw the wheel according to current parent width
+    this.resize = () => {
+      const parent = this.app.view.parentNode
 
-      const graphics = new PIXI.Graphics()
-      graphics.lineStyle(4, 0x000000, 1)
-      graphics.beginFill(calculatedSegment.backgroundColour)
-      graphics.moveTo(0, 0)
-      graphics.arc(0, 0, radius, 0, deg2rad(calculatedSegment.degrees))
-      graphics.lineTo(0, 0)
-      graphics.closePath()
-      graphics.endFill()
-      segment.addChild(graphics)
+      // Redraw all graphics from scratch
+      this.wheel.removeChildren()
 
-      const text = new PIXI.Text(calculatedSegment.label)
-      // text.anchor.set(0, 0.5)
-      text.angle = calculatedSegment.degrees / 2
-      text.x = radius * 0.25
-      text.y = text.angle - (text.height / 2)
-      segment.addChild(text)
+      // Resize the canvas
+      this.app.renderer.resize(parent.clientWidth, parent.clientWidth)
 
-      degreesUsed += calculatedSegment.degrees
-      segment.angle = degreesUsed
-      wheel.addChild(segment)
+      // Draw the wheel to the new canvas size
+      const maxLength = this.app.view.clientWidth
+      this.wheel.x = maxLength / 2
+      this.wheel.y = maxLength / 2
+      this.radius = maxLength / 2 - 10
+      drawWheel(this.wheel, this.radius, this.calculatedSegments)
     }
-
-    this.app.stage.addChild(wheel)
 
     // TODO spin to selected segment on click event
     // for now, just spin attractively
     let count = 0
     this.app.ticker.add(() => {
       count += 0.1
-      wheel.rotation = count * 0.1
+      this.wheel.rotation = count * 0.1
     })
 
     this.$refs.myCanvas.appendChild(this.app.view)
+    this.resize()
+    window.addEventListener('resize', this.resize)
+  },
+  updated: function () {
+    this.calculatedSegments = calculateSegments(this.segments)
+    this.resize()
+  },
+  beforeDestroy: function () {
+    window.removeEventListener('resize', this.resize)
   }
 }
 
@@ -106,7 +97,7 @@ function calculateSegments (segments) {
   let calculatedSegments = []
   let arcLeft = 360
   let degreesEach = arcLeft / segments.length
-  
+
   let currentDegree = 0
   for (const segment of segments) {
     let calculatedSegment = {
@@ -122,6 +113,37 @@ function calculateSegments (segments) {
   }
 
   return calculatedSegments
+}
+
+function drawWheel (container, radius, segmentsData) {
+  let degreesUsed = 0
+  for (const segmentData of segmentsData) {
+    const segment = new PIXI.Container()
+
+    // Create the pie slice
+    const graphics = new PIXI.Graphics()
+    graphics.lineStyle(4, 0x000000, 1)
+    graphics.beginFill(segmentData.backgroundColour)
+    graphics.moveTo(0, 0)
+    graphics.arc(0, 0, radius, 0, deg2rad(segmentData.degrees))
+    graphics.lineTo(0, 0)
+    graphics.closePath()
+    graphics.endFill()
+    segment.addChild(graphics)
+
+    // Put a label on the pie slice
+    const fontSize = radius / 10
+    const text = new PIXI.Text(`    ${segmentData.label}`, { fontSize: fontSize })
+    text.angle = segmentData.degrees / 2
+    text.x = text.height
+    text.y = 0
+    segment.addChild(text)
+
+    // Add the slice to the wheel
+    degreesUsed += segmentData.degrees
+    segment.angle = degreesUsed
+    container.addChild(segment)
+  }
 }
 
 function deg2rad (degrees) {


### PR DESCRIPTION
 Rework SpinWheel to be mobile-friendly

- Improve drawing algorithm so that it works at any size
- Update grid and css so the wheel is size/placed for mobile
- Add resize listener so the wheel is redrawn at the right size